### PR TITLE
Fix agent typing for Claude SDK and clean CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,50 +66,6 @@ jobs:
         name: codecov-umbrella
         fail_ci_if_error: false
 
-  integration-tests:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
-      with:
-        version: "latest"
-    
-    - name: Set up Python 3.12
-      run: uv python install 3.12
-    
-    - name: Install dependencies
-      run: |
-        uv sync --all-extras
-    
-    - name: Install Node.js for MCP servers
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-    
-    - name: Install MCP servers
-      run: |
-        npm install -g @modelcontextprotocol/server-filesystem
-        uv tool install mcp-server-fetch
-    
-    - name: Set up Docker for SQLite MCP server
-      uses: docker/setup-buildx-action@v3
-    
-    - name: Pull SQLite MCP server image
-      run: |
-        docker pull mcp/sqlite
-    
-    - name: Run integration tests (without real LLM)
-      run: |
-        uv run pytest tests/test_integration.py tests/test_integration_simple.py -v
-      env:
-        # Don't run tests requiring real API keys in CI
-        SKIP_REAL_LLM_TESTS: "true"
-
   security-scan:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ smolval = "smolval.cli:cli"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
     "pytest-docker>=2.0.0",

--- a/src/smolval/models/agent.py
+++ b/src/smolval/models/agent.py
@@ -5,8 +5,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from claude_agent_sdk import Message
-
 
 class AgentStep(BaseModel):
     """Represents a single step in the agent's execution."""
@@ -38,10 +36,11 @@ class ExecutionMetadata(BaseModel):
     session_id: str
     execution_start: datetime
     execution_end: datetime
+    model_used: str | None = None
     total_cost_usd: float | None = None
     total_usage: dict[str, Any] | None = None
-    mcp_servers_used: list[str] = []
-    tools_available: list[str] = []
+    mcp_servers_used: list[str] = Field(default_factory=list)
+    tools_available: list[str] = Field(default_factory=list)
 
 
 class AgentResult(BaseModel):

--- a/tests/test_claude_code_agent.py
+++ b/tests/test_claude_code_agent.py
@@ -1,7 +1,7 @@
 """Tests for ClaudeCodeAgent."""
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
## Summary
- align ClaudeCodeAgent with updated claude-agent-sdk types and normalize tool output metadata
- migrate dev dependencies to the new uv dependency-groups block and drop the stale integration job from CI
- replace AGENTS.md with a symlink to CLAUDE.md so we only maintain one contributor guide

## Testing
- uv run mypy src/ --show-error-codes
- uv run ruff check src/ tests/ --output-format=github
- uv run black --check src/ tests/
- uv run isort --check-only src/ tests/
- uv run pytest
- uv run pytest -m "not integration and not slow" --cov=smolval --cov-report=xml --cov-report=term-missing
